### PR TITLE
Enable automatic branch deletion after merge

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,2 @@
+repository:
+  delete_branch_on_merge: true


### PR DESCRIPTION
## Summary
- enable automatic deletion of branches after they are merged by enabling GitHub's delete_branch_on_merge setting

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b315e7e4fc832d9ab6d794ae81ebf7