### PR TITLE
fix: enforce IPv4 for remote DB

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,7 +62,9 @@ jobs:
           ENC_PASS=$(python3 -c "import os, urllib.parse; print(urllib.parse.quote(os.environ['SUPABASE_DB_PASSWORD'], safe=''))")
           echo "::add-mask::$ENC_PASS"
           if [ -z "${PROJECT_REF:-}" ]; then echo "::error::PROJECT_REF not set"; exit 1; fi
-          DB_URL="postgresql://postgres:${ENC_PASS}@db.${PROJECT_REF}.supabase.co:5432/postgres?sslmode=require"
+          DB_HOST="db.${PROJECT_REF}.supabase.co"
+          DB_HOST_IP=$(getent ahostsv4 "$DB_HOST" | awk '{print $1; exit}')
+          DB_URL="postgresql://postgres:${ENC_PASS}@${DB_HOST}:5432/postgres?hostaddr=${DB_HOST_IP}&sslmode=require"
           supabase db push --db-url "$DB_URL"
 
       - name: Set Edge Function secrets


### PR DESCRIPTION
## Summary
- resolve remote database host to IPv4 and provide hostaddr to avoid IPv6 connection failures in deploy workflow

## Testing
- `pip install --quiet yamllint` *(fails: Could not find a version that satisfies the requirement yamllint)*
- `yamllint .github/workflows/deploy.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf05ad9dcc832d83b1aedaae087294