### PR TITLE
ci: use repository secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,6 @@ on:
 
 jobs:
   deploy:
-    environment: PROD
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- remove PROD environment from deploy workflow so it reads repository secrets directly

## Testing
- `make test-db` *(fails: psql not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0a60a40c832dad528913a065f4e4